### PR TITLE
chore: remove rubra API endpoints and combine assistant tools

### DIFF
--- a/server/routes/v1/assistants/[assistant]/index.put.ts
+++ b/server/routes/v1/assistants/[assistant]/index.put.ts
@@ -2,18 +2,13 @@ export default defineEventHandler(async (event) => {
   const assistantId = event.context.params?.assistant || ''
   const json = await readBody(event)
 
-  json.tools = ((json.tools || []) as string[]).map((x) => {
-    return { type: x }
-  }) as any
-  // json.gptscript_tools = (json.gptscript_tools || []).map(x => { return {type: x} }) as any
-
   delete json.created_at
   delete json.id
   delete json.object
 
   console.debug('Update assistant', assistantId, json)
 
-  const res = await apiFetch(`/v1/rubra/assistants/${ encodeURIComponent(assistantId) }`, 'POST', json)
+  const res = await apiFetch(`/v1/assistants/${ encodeURIComponent(assistantId) }`, 'POST', json)
 
   setResponseStatus(event, res._status)
 

--- a/server/routes/v1/assistants/index.post.ts
+++ b/server/routes/v1/assistants/index.post.ts
@@ -1,12 +1,7 @@
 export default defineEventHandler(async (event) => {
   const json = await readBody(event)
 
-  json.tools = (json.tools || []).map((x) => {
-    return { type: x }
-  }) as any
-  // json.gptscript_tools = (json.gptscript_tools || []).map(x => { return {type: x} }) as any
-
-  const res = await apiFetch('/v1/rubra/assistants', 'POST', json)
+  const res = await apiFetch('/v1/assistants', 'POST', json)
 
   setResponseStatus(event, res._status)
 

--- a/server/routes/v1/assistants/index.ts
+++ b/server/routes/v1/assistants/index.ts
@@ -1,5 +1,5 @@
 import type { Assistant } from 'openai/resources/beta/assistants'
 
 export default defineEventHandler(async (_event) => {
-  return apiList<Assistant>('/v1/rubra/assistants')
+  return apiList<Assistant>('/v1/assistants')
 })

--- a/server/routes/v1/threads/index.ts
+++ b/server/routes/v1/threads/index.ts
@@ -2,7 +2,7 @@ import type { Thread } from 'openai/resources/beta/threads'
 import { apiList } from '@/server/utils/api'
 
 export default defineEventHandler(async (_event) => {
-  const threads = await apiList<Thread>('/v1/rubra/x/threads')
+  const threads = await apiList<Thread>('/v1/x-threads')
 
   return threads
 })

--- a/server/routes/v1/tools/[tool]/index.delete.ts
+++ b/server/routes/v1/tools/[tool]/index.delete.ts
@@ -1,7 +1,7 @@
 export default defineEventHandler(async (event) => {
   const toolId = event.context.params?.tool || ''
 
-  const res = await apiFetch(`/v1/rubra/x/tools/${ toolId }`, 'DELETE')
+  const res = await apiFetch(`/v1/x-tools/${ toolId }`, 'DELETE')
 
   return res
 })

--- a/server/routes/v1/tools/[tool]/index.put.ts
+++ b/server/routes/v1/tools/[tool]/index.put.ts
@@ -2,7 +2,7 @@ export default defineEventHandler(async (event) => {
   const toolId = event.context.params?.tool || ''
   const json = await readBody(event)
 
-  const res = await apiFetch(`/v1/rubra/x/tools/${ toolId }`, 'PUT', json)
+  const res = await apiFetch(`/v1/x-tools/${ toolId }`, 'PUT', json)
 
   return res
 })

--- a/server/routes/v1/tools/[tool]/index.ts
+++ b/server/routes/v1/tools/[tool]/index.ts
@@ -1,7 +1,7 @@
 export default defineEventHandler(async (event) => {
   const toolId = event.context.params?.tool || ''
 
-  const res = await apiFetch(`/v1/rubra/x/tools/${ toolId }`)
+  const res = await apiFetch(`/v1/x-tools/${ toolId }`)
 
   return res
 })

--- a/server/routes/v1/tools/index.post.ts
+++ b/server/routes/v1/tools/index.post.ts
@@ -1,6 +1,6 @@
 export default defineEventHandler(async (event) => {
   const json = await readBody(event)
-  const res = await apiFetch('/v1/rubra/x/tools', 'POST', json)
+  const res = await apiFetch('/v1/x-tools', 'POST', json)
 
   setResponseStatus(event, res._status)
 

--- a/server/routes/v1/tools/index.ts
+++ b/server/routes/v1/tools/index.ts
@@ -5,7 +5,7 @@ export default defineEventHandler(async (_event) => {
   const tools: ToolObject[] = []
 
   console.debug('Listing tools')
-  const res = await apiFetch('/v1/rubra/x/tools')
+  const res = await apiFetch('/v1/x-tools')
 
   setResponseStatus(res._status)
 


### PR DESCRIPTION
This change removes the /v1/rubra and /v1/rubra/x endpoints, and combines the assistant tools and gptscript_tools field for a simpler API experience.