### PR TITLE
enhance: run production builds for ui tool on npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "gptscript-ui",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@gptscript-ai/gptscript": "^0.9.2",
         "@nextui-org/button": "2.0.32",
@@ -55,6 +56,7 @@
         "typescript": "5.0.4"
       },
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "eslint": "^8.57.0"
       }
     },
@@ -5654,6 +5656,25 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   "scripts": {
     "dev": "node server.mjs",
     "build": "next build --no-lint",
-    "start": "node server.mjs",
     "lint": "next lint",
     "debug": "node --inspect server.mjs",
-    "server": "node server.mjs"
+    "start": "cross-env NODE_ENV='production' node server.mjs",
+    "postinstall": "cross-env NODE_ENV='production' npm run build",
+    "dev-install": "npm install --ignore-scripts"
   },
   "dependencies": {
     "@gptscript-ai/gptscript": "^0.9.2",
@@ -63,6 +64,7 @@
     "typescript": "5.0.4"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "eslint": "^8.57.0"
   }
 }

--- a/tool.gpt
+++ b/tool.gpt
@@ -1,1 +1,1 @@
-#!sys.daemon (path=/api/readyz) /usr/bin/env npm run --prefix ${GPTSCRIPT_TOOL_DIR} dev
+#!sys.daemon (path=/api/readyz) /usr/bin/env npm run --prefix ${GPTSCRIPT_TOOL_DIR} start


### PR DESCRIPTION
Add a postinstall script to ensure the production NextJS build is generated on `npm install`. This enables `gptscript --ui` to run production UI builds.

