### PR TITLE
fix: set workspace dir from correct env var

### DIFF
--- a/config/env.ts
+++ b/config/env.ts
@@ -2,12 +2,11 @@ import {GPTScript} from "@gptscript-ai/gptscript"
 import path from "path";
 
 export const SCRIPTS_PATH = () => process.env.SCRIPTS_PATH || "gptscripts";
-export const WORKSPACE_DIR = () => process.env.GPTSCRIPT_WORKSPACE_DIR || "";
+export const WORKSPACE_DIR = () => process.env.WORKSPACE_DIR || "";
 export const THREADS_DIR = () => process.env.THREADS_DIR || path.join(WORKSPACE_DIR(), "threads");
 export const GATEWAY_URL = () => process.env.GATEWAY_URL || "http://localhost:8080";
 
 export const set_WORKSPACE_DIR = (dir: string) => process.env.GPTSCRIPT_WORKSPACE_DIR = dir;
-export const set_SCRIPTS_PATH = (dir: string) => process.env.SCRIPTS_PATH = dir;
 
 let gptscript: GPTScript | null = null;
 

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -5,7 +5,7 @@ import { join, dirname } from "path";
 import { existsSync, mkdirSync } from "fs";
 import fixPath from "fix-path";
 
-const appName = 'assistant-studio'; // Replace with your app's name
+const appName = 'Assistant Studio';
 const gatewayUrl = process.env.GATEWAY_URL || 'https://gateway-api.gptscript.ai';
 const resourcesDir = dirname(app.getAppPath());
 const dataDir = getDataDir(appName);

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -2,21 +2,17 @@ import { app, BrowserWindow } from "electron";
 import { getPort } from 'get-port-please';
 import { startAppServer } from '../server/app.mjs';
 import { join, dirname } from "path";
-import { homedir } from "os";
 import { existsSync, mkdirSync } from "fs";
 import fixPath from "fix-path";
 
 const appName = 'assistant-studio'; // Replace with your app's name
 const gatewayUrl = process.env.GATEWAY_URL || 'https://gateway-api.gptscript.ai';
 const resourcesDir = dirname(app.getAppPath());
-const cacheDir = getCacheDir(appName);
+const dataDir = getDataDir(appName);
 
-function getCacheDir(appName) {
-  const platform = process.platform;
-  const baseDir = platform === 'win32' ? process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local') :
-                  platform === 'darwin' ? join(homedir(), 'Library', 'Caches') :
-                  process.env.XDG_CACHE_HOME || join(homedir(), '.cache');
-  return join(baseDir, appName);
+function getDataDir(appName) {
+  const userDataPath = app.getPath('userData');
+  return join(userDataPath, appName);
 }
 
 function ensureDirExists(dir) {
@@ -28,9 +24,11 @@ async function startServer(isPackaged) {
   const gptscriptBin = join(isPackaged ? resourcesDir : "", "node_modules", "@gptscript-ai", "gptscript", "bin", `gptscript${process.platform === "win32" ? ".exe" : ""}`);
 
   process.env.GPTSCRIPT_BIN = process.env.GPTSCRIPT_BIN || gptscriptBin;
-  process.env.THREADS_DIR = process.env.THREADS_DIR || join(cacheDir, "threads");
-  process.env.WORKSPACE_DIR = process.env.WORKSPACE_DIR || join(cacheDir, "workspace");
+  process.env.THREADS_DIR = process.env.THREADS_DIR || join(dataDir, "threads");
+  process.env.WORKSPACE_DIR = process.env.WORKSPACE_DIR || join(dataDir, "workspace");
   process.env.GATEWAY_URL = process.env.GATEWAY_URL || gatewayUrl;
+
+  console.log(`Starting app server with GPTSCRIPT_BIN="${process.env.GPTSCRIPT_BIN}"`);
 
   try {
     const url = await startAppServer({ dev: !isPackaged, hostname: 'localhost', port, dir: app.getAppPath() });
@@ -62,7 +60,7 @@ function createWindow(url) {
 
 app.on("ready", () => {
   fixPath();
-  ensureDirExists(cacheDir);
+  ensureDirExists(dataDir);
   startServer(app.isPackaged);
 });
 

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -27,6 +27,7 @@ async function startServer(isPackaged) {
   process.env.THREADS_DIR = process.env.THREADS_DIR || join(dataDir, "threads");
   process.env.WORKSPACE_DIR = process.env.WORKSPACE_DIR || join(dataDir, "workspace");
   process.env.GATEWAY_URL = process.env.GATEWAY_URL || gatewayUrl;
+  process.env.DISABLE_CACHE = "true"; // TODO: Remove after https://github.com/gptscript-ai/gptscript/issues/713 is addressed
 
   console.log(`Starting app server with GPTSCRIPT_BIN="${process.env.GPTSCRIPT_BIN}"`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "v0.9.4",
       "hasInstallScript": true,
       "dependencies": {
-        "@gptscript-ai/gptscript": "^0.9.2",
+        "@gptscript-ai/gptscript": "^0.9.4",
         "@monaco-editor/react": "^4.6.0",
         "@nextui-org/button": "2.0.32",
         "@nextui-org/code": "2.0.28",
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@gptscript-ai/gptscript": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@gptscript-ai/gptscript/-/gptscript-0.9.3.tgz",
-      "integrity": "sha512-+pCGkoJzOXHABrPKJlZedtr8QrvenqKm+9BKCUxBNyPaMFGW4HxeyLbIKBrAsUjKKly2lxHpvwGaQbOtU7P0dQ==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@gptscript-ai/gptscript/-/gptscript-0.9.4.tgz",
+      "integrity": "sha512-3Cjrzy5o7y+Y+CRG9QhJttmAfa7iJNesh/08kcqvm+qvawDBchJqb8zhpuE1D741HfnNGLV1CIYP9FQMTHvGBQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "main": "electron/main.mjs",
   "dependencies": {
-    "@gptscript-ai/gptscript": "^0.9.2",
+    "@gptscript-ai/gptscript": "^0.9.4",
     "@monaco-editor/react": "^4.6.0",
     "@nextui-org/button": "2.0.32",
     "@nextui-org/code": "2.0.28",

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -12,7 +12,6 @@ dotenv.config({path: ['../.env', '../.env.local']});
 const AGENT = 1;
 const USER = 2;
 const STATE_FILE = "state.json";
-const DISABLE_CACHE = process.env.DISABLE_CACHE === "true";
 let runningScript = null;
 let serverRunning = false;
 


### PR DESCRIPTION
- Get the `WORKSPACE_DIR` env var instead of `GPTSCRIPT_WORKSPACE_DIR` (the former is set by the electron app at startup)
- Store threads and workspaces in the data dir instead of the cache dir
- Bump node-gptscript to v0.9.4
- Hardcode disable cache as stopgap for https://github.com/gptscript-ai/gptscript/issues/713
