### PR TITLE
chore: ignore release time when publishing electron builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EP_GH_IGNORE_TIME: true
+          EP_DRAFT: false
           APPLE_API_KEY: /tmp/apikey.p8
           APPLE_API_KEY_ID: ${{ secrets.ELECTRON_APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.ELECTRON_APPLE_API_ISSUER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Build Electron app
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EP_GH_IGNORE_TIME: true
           APPLE_API_KEY: /tmp/apikey.p8
           APPLE_API_KEY_ID: ${{ secrets.ELECTRON_APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.ELECTRON_APPLE_API_ISSUER }}

--- a/electron/build.mjs
+++ b/electron/build.mjs
@@ -90,11 +90,15 @@ function go() {
     }
     console.log(`targetPlatform: ${targetPlatform}`)
 
+    // Only publish when the GH_TOKEN is set.
+    // This indicates the intent to publish the build to a release.
+    const publishOption = process.env.GH_TOKEN ? 'always' : 'never';
+
     builder
         .build({
             targets: Platform[targetPlatform.toUpperCase()].createTarget(),
             config: options,
-            publish: 'always',
+            publish: publishOption,
         })
         .then((result) => {
             console.info('----------------------------');


### PR DESCRIPTION
- Allow publishing to releases that are more than 2 hours old
- Ensure builds are published to non-draft releases
