### PR TITLE
Fix socket reconnect issue that event emitter is lost

### DIFF
--- a/components/script/useChatSocket.tsx
+++ b/components/script/useChatSocket.tsx
@@ -14,6 +14,7 @@ const useChatSocket = (isEmpty?: boolean) => {
     const [running, setRunning] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [tools, setTools] = useState<string[]>([]);
+    const [forceRun, setForceRun] = useState(true);
 
     // Refs
     const socketRef = useRef<Socket | null>(null);
@@ -259,8 +260,13 @@ const useChatSocket = (isEmpty?: boolean) => {
         setConnected(false);
         setMessages([]);
 
-        socket.on("connect", () => setConnected(true));
-        socket.on("disconnect", () => setConnected(false));
+        socket.on("connect", () => {
+            setConnected(true);
+        });
+        socket.on("disconnect", () => {
+            setConnected(false);
+            setForceRun(true);
+        });
         socket.on("running", () => setRunning(true));
         socket.on("progress", (data: { frame: CallFrame, state: any }) => handleProgress(data));
         socket.on("error", (data: string) => handleError(data));
@@ -331,6 +337,8 @@ const useChatSocket = (isEmpty?: boolean) => {
         setRunning,
         tools,
         setTools,
+        forceRun,
+        setForceRun,
     };
 };
 

--- a/contexts/script.tsx
+++ b/contexts/script.tsx
@@ -81,7 +81,7 @@ const ScriptContextProvider: React.FC<ScriptContextProps> = ({children, initialS
     const [initialFetch, setInitialFetch] = useState(false);
     const [subTool, setSubTool] = useState(initialSubTool || '');
     const { 
-        socket, connected, running, messages, setMessages, restart, interrupt, generating, error, setRunning, tools, setTools
+        socket, connected, running, messages, setMessages, restart, interrupt, generating, error, setRunning, tools, setTools, forceRun, setForceRun
     } = useChatSocket(isEmpty);
 
     // need to initialize the workspace from the env variable with serves
@@ -136,6 +136,13 @@ const ScriptContextProvider: React.FC<ScriptContextProps> = ({children, initialS
 			setHasRun(true);
 		}
 	}, [tool, connected, scriptContent, formValues, workspace, thread]);
+
+	useEffect(() => {
+		if (forceRun && socket && connected) {
+			socket.emit("run", script, subTool ? subTool : tool.name, formValues, workspace, thread)
+			setForceRun(false);
+		}
+	}, [forceRun, connected]);
 
 	useEffect(() => {
 		const smallBody = document.getElementById("small-message");


### PR DESCRIPTION
This PR fixes an issue where socket's event emitter will be lost once socket is reconnected. This happens when app lost network connection, causing socket to reconnect but the server socket is reconnected and lose all the event listener including user-message. This causes an issue where typing user message doesn't trigger anything in UI.

Added the functionality to manually trigger the `run` event through the socket to re-add all the custom event listeners.